### PR TITLE
Removes nbsp tags and gupy_public_page url param

### DIFF
--- a/source/data/usecases/extract-jobs.usecase.ts
+++ b/source/data/usecases/extract-jobs.usecase.ts
@@ -41,6 +41,7 @@ export class ExtractJobsUseCase {
     rootUrl: string
   ): Promise<Job> {
     let url = $rootUrlHTML(jobElement).find('a').attr('href')
+    url = url.replace('?jobBoardSource=gupy_public_page', '')
 
     if (url.length > 0 && url.slice(0, 1) === '/') {
       url = `${rootUrl}${url}`
@@ -127,6 +128,16 @@ export class ExtractJobsUseCase {
       $el.find('[style]').removeAttr('style')
       $el.find('br').remove()
       $el.find('a').remove()
+
+      for (let i = 0; i < 2; i++) {
+        $el.find('*').each((index, el) => {
+          const html = $jobUrlHTML(el).html()
+
+          if (html === '&nbsp;' || html === '') {
+            $el.find(el).remove()
+          }
+        })
+      }
 
       const text = $el.html()
 


### PR DESCRIPTION
## Description of changes
This PR removes nbsp tags and gupy_public_page url param.

## Issue ticket number and link
This addresses:
- [STA-383](https://linear.app/startec/issue/STA-383/[crawler]-inserir-validacao-para-remover-tags-non-breaking-space)
- [STA-393](https://linear.app/startec/issue/STA-393/[crawler]-remover-fonte-de-acesso-das-urls-das-vagas-da-gupy)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (code update that doesn't fix a bug or add a new feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
